### PR TITLE
Ajout intégration qualité de l'air Montréal

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -36,3 +36,4 @@ Ces projets extérieurs à Domo Québec pourraient vous intéresser.
 | Intégration des données d'Hydro-Québec | https://hydroqc.ca |
 | Intégration Home-Assistant Hilo | https://github.com/dvd-dev/hilo |
 | Intégration Home-Assistant Sinopé | https://github.com/claudegel |
+| Intégration Home-Assistant Qualité de l'air Montréal | https://github.com/normcyr/home-assistant-montreal-aqi |


### PR DESCRIPTION
Mise à jour de la liste des autres projets extérieurs d'intérêt en y ajoutant l'intégration HA qui fournit des données sur la qualité de l'air pour la Ville de Montréal.